### PR TITLE
Support JournalEntryLineItem class + entity

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ledger_sync-netsuite (0.3.2)
+    ledger_sync-netsuite (0.3.3)
       dotenv
       ledger_sync (>= 2.0.0)
       nokogiri
@@ -44,7 +44,7 @@ GEM
     dry-container (0.7.2)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.5.0)
+    dry-core (0.6.0)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.3.0)
     dry-inflector (0.2.0)
@@ -97,7 +97,6 @@ GEM
     hashdiff (1.0.1)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    io-wait (0.1.0)
     json (2.5.1)
     jwt (2.2.3)
     ledger_sync (2.0.0)
@@ -115,19 +114,12 @@ GEM
       rack (~> 2.2.3)
       resonad
       simply_serializable (>= 1.5.1)
-    mini_portile2 (2.5.2)
-      net-ftp (~> 0.1)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    net-ftp (0.1.2)
-      net-protocol
-      time
-    net-protocol (0.1.1)
-      io-wait
-      timeout
-    nokogiri (1.11.6)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     oauth2 (1.4.7)
@@ -187,8 +179,6 @@ GEM
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (1.1.0)
-    time (0.1.0)
-    timeout (0.1.1)
     tins (1.29.1)
       sync
     tzinfo (2.0.4)

--- a/lib/ledger_sync/netsuite/journal_entry/deserializer.rb
+++ b/lib/ledger_sync/netsuite/journal_entry/deserializer.rb
@@ -20,7 +20,6 @@ module LedgerSync
         references_one :currency
 
         references_one :subsidiary
-        references_one :ledger_class, hash_attribute: :class, deserializer: LedgerClass::Deserializer
 
         references_many :line_items,
                         hash_attribute: 'line.items',

--- a/lib/ledger_sync/netsuite/journal_entry/operations/create.rb
+++ b/lib/ledger_sync/netsuite/journal_entry/operations/create.rb
@@ -14,7 +14,6 @@ module LedgerSync
               required(:tranId).maybe(:string)
               required(:currency).maybe(:hash, Types::Reference)
               required(:subsidiary).maybe(:hash, Types::Reference)
-              required(:ledger_class).maybe(:hash, Types::Reference)
               required(:line_items).array(Types::Reference)
             end
           end

--- a/lib/ledger_sync/netsuite/journal_entry/operations/delete.rb
+++ b/lib/ledger_sync/netsuite/journal_entry/operations/delete.rb
@@ -14,7 +14,6 @@ module LedgerSync
               optional(:tranId).maybe(:string)
               optional(:currency).maybe(:hash, Types::Reference)
               optional(:subsidiary).maybe(:hash, Types::Reference)
-              required(:ledger_class).maybe(:hash, Types::Reference)
               optional(:line_items).array(Types::Reference)
             end
           end

--- a/lib/ledger_sync/netsuite/journal_entry/operations/find.rb
+++ b/lib/ledger_sync/netsuite/journal_entry/operations/find.rb
@@ -14,7 +14,6 @@ module LedgerSync
               optional(:tranId).maybe(:string)
               optional(:currency).maybe(:hash, Types::Reference)
               optional(:subsidiary).maybe(:hash, Types::Reference)
-              required(:ledger_class).maybe(:hash, Types::Reference)
               optional(:line_items).array(Types::Reference)
             end
           end

--- a/lib/ledger_sync/netsuite/journal_entry/operations/update.rb
+++ b/lib/ledger_sync/netsuite/journal_entry/operations/update.rb
@@ -14,7 +14,6 @@ module LedgerSync
               required(:tranId).maybe(:string)
               required(:currency).maybe(:hash, Types::Reference)
               required(:subsidiary).maybe(:hash, Types::Reference)
-              required(:ledger_class).maybe(:hash, Types::Reference)
               required(:line_items).array(Types::Reference)
             end
           end

--- a/lib/ledger_sync/netsuite/journal_entry/serializer.rb
+++ b/lib/ledger_sync/netsuite/journal_entry/serializer.rb
@@ -17,9 +17,6 @@ module LedgerSync
         references_one :currency,
                        serializer: Reference::Serializer, if: :currency_present?
 
-        references_one :ledger_class,
-                       serializer: LedgerClass::Serializer
-
         references_one :subsidiary,
                        serializer: Reference::Serializer
 

--- a/lib/ledger_sync/netsuite/journal_entry_line_item/deserializer.rb
+++ b/lib/ledger_sync/netsuite/journal_entry_line_item/deserializer.rb
@@ -11,6 +11,11 @@ module LedgerSync
         attribute :credit
         attribute :debit
         attribute :memo
+        attribute :entity,
+                  type: Type::DeserializerEntityType.new
+        references_one :ledger_class,
+                       hash_attribute: :class,
+                       deserializer: LedgerClass::Deserializer
         references_one :account
       end
     end

--- a/lib/ledger_sync/netsuite/journal_entry_line_item/serializer.rb
+++ b/lib/ledger_sync/netsuite/journal_entry_line_item/serializer.rb
@@ -10,6 +10,11 @@ module LedgerSync
         attribute :credit
         attribute :debit
         attribute :memo
+        references_one :entity,
+                       serializer: Reference::Serializer
+        references_one :class,
+                       resource_attribute: :ledger_class,
+                       serializer: Reference::Serializer
         references_one :account,
                        serializer: Reference::Serializer
       end

--- a/lib/ledger_sync/netsuite/resources/journal_entry.rb
+++ b/lib/ledger_sync/netsuite/resources/journal_entry.rb
@@ -13,7 +13,6 @@ module LedgerSync
 
       references_one :currency, to: Currency
       references_one :subsidiary, to: Subsidiary
-      references_one :ledger_class, to: LedgerClass
 
       references_many :line_items, to: JournalEntryLineItem
 

--- a/lib/ledger_sync/netsuite/resources/journal_entry_line_item.rb
+++ b/lib/ledger_sync/netsuite/resources/journal_entry_line_item.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 require_relative 'account'
+require_relative 'customer'
 require_relative 'department'
 require_relative 'ledger_class'
+require_relative 'vendor'
 
 module LedgerSync
   module NetSuite
     class JournalEntryLineItem < NetSuite::Resource
       references_one :account, to: Account
+      references_one :entity, to: [Customer, Vendor]
+      references_one :ledger_class, to: LedgerClass
       attribute :line, type: Type::Integer
       attribute :credit, type: Type::Float
       attribute :debit, type: Type::Float

--- a/lib/ledger_sync/netsuite/version.rb
+++ b/lib/ledger_sync/netsuite/version.rb
@@ -3,7 +3,7 @@
 # :nocov:
 module LedgerSync
   module NetSuite
-    VERSION = '0.3.2'
+    VERSION = '0.3.3'
 
     def self.version
       if ENV['PRE_RELEASE']


### PR DESCRIPTION
Enables us to populate "name" (e.g. a "customer" or "vendor") and "class" for JournalEntry object:
![image](https://user-images.githubusercontent.com/874324/120705884-fbd61700-c47d-11eb-8c18-a691db1be3a4.png)

