### PR TITLE
Construct URI safely

### DIFF
--- a/lib/ledger_sync/netsuite/client.rb
+++ b/lib/ledger_sync/netsuite/client.rb
@@ -42,7 +42,12 @@ module LedgerSync
       end
 
       def api_base_url
-        @api_base_url ||= "https://#{api_host}/services/rest/record/v1"
+        @api_base_url ||= URI::HTTPS.build(
+          host: api_host,
+          path: '/services/rest/record/v1'
+        ).to_s
+      rescue URI::InvalidComponentError => e
+        raise LedgerSync::Error::LedgerError::ConfigurationError, e.message
       end
 
       def api_host

--- a/lib/ledger_sync/netsuite/client.rb
+++ b/lib/ledger_sync/netsuite/client.rb
@@ -47,7 +47,7 @@ module LedgerSync
           path: '/services/rest/record/v1'
         ).to_s
       rescue URI::InvalidComponentError => e
-        raise LedgerSync::Error::LedgerError::ConfigurationError, e.message
+        raise LedgerSync::Error::LedgerError::ConfigurationError, client: self, message: e.message
       end
 
       def api_host

--- a/lib/ledger_sync/netsuite/client.rb
+++ b/lib/ledger_sync/netsuite/client.rb
@@ -47,7 +47,7 @@ module LedgerSync
           path: '/services/rest/record/v1'
         ).to_s
       rescue URI::InvalidComponentError => e
-        raise LedgerSync::Error::LedgerError::ConfigurationError, client: self, message: e.message
+        raise LedgerSync::Error::LedgerError::ConfigurationError.new(client: self, message: e.message)
       end
 
       def api_host

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe LedgerSync::NetSuite::Client do
       consumer_key: consumer_key,
       consumer_secret: consumer_secret,
       token_id: token_id,
-      token_secret: token_secret,
+      token_secret: token_secret
     )
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -17,12 +17,31 @@ RSpec.describe LedgerSync::NetSuite::Client do
 
   subject do
     described_class.new(
-      access_token: access_token,
-      client_id: client_id,
-      client_secret: client_secret,
-      realm_id: realm_id,
-      refresh_token: refresh_token,
-      test: test
+      account_id: account_id,
+      consumer_key: consumer_key,
+      consumer_secret: consumer_secret,
+      token_id: token_id,
+      token_secret: token_secret,
     )
+  end
+
+  context 'when preventing local urls in api_base_url' do
+    let(:api_base_url) { subject.api_base_url }
+
+    context 'when account_id is localhost/#' do
+      let(:account_id) { 'localhost/#' }
+
+      it 'does not permit localhost/# for account_id' do
+        expect { api_base_url }.to raise_error(LedgerSync::Error::LedgerError::ConfigurationError)
+      end
+    end
+
+    context 'when account_id is 127.0.0.1/#' do
+      let(:account_id) { '127.0.0.1/#' }
+
+      it 'does not permit 127.0.0.1/# for account_id' do
+        expect { api_base_url }.to raise_error(LedgerSync::Error::LedgerError::ConfigurationError)
+      end
+    end
   end
 end


### PR DESCRIPTION
You can construct an "unsafe" URL by passing in something like `1.2.3.4/#` as the NetSuite Account ID. This becomes `https://1.2.3.4/#.suitetalk.api.netsuite.com/services/rest/record/v1` and you can see that's just `https://1.2.3.4` with a fragment of `.suitetalk.api.netsuite.com/services/rest/record/v1`.