### PR TITLE
Prepare for LedgerSync 3.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ledger_sync-netsuite (0.6.2)
       dotenv
-      ledger_sync (>= 2.4)
+      ledger_sync (>= 2.4, <= 3.0)
       nokogiri
       oauth2
 

--- a/ledger_sync-netsuite.gemspec
+++ b/ledger_sync-netsuite.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('simplecov-lcov')
   spec.add_development_dependency('webmock', '>= 0')
   spec.add_runtime_dependency('dotenv')
-  spec.add_runtime_dependency('ledger_sync', '>= 2.4')
+  spec.add_runtime_dependency('ledger_sync', '>= 2.4', '<= 3.0')
   spec.add_runtime_dependency('nokogiri', '>= 0')
   spec.add_runtime_dependency('oauth2', '>= 0')
 


### PR DESCRIPTION
LedgerSync 3.0 will introduce breaking changes, namely fixing the minimum ruby version to 3.1. This PR is to prevent unintentional ERP-specific gem upgrades.